### PR TITLE
Fix generator naming.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Bundle your dependencies and run the installation generator:
 
 ```shell
 bundle
-bundle exec rails g spree_asset_variant_options:install
+bundle exec rails g solidus_asset_variant_options:install
 ```
 
 Since this extension changes the way images are associated, if you've got any

--- a/lib/generators/solidus_asset_variant_options/install/install_generator.rb
+++ b/lib/generators/solidus_asset_variant_options/install/install_generator.rb
@@ -1,4 +1,4 @@
-module SpreeAssetVariantOptions
+module SolidusAssetVariantOptions
   module Generators
     class InstallGenerator < Rails::Generators::Base
       class_option :auto_run_migrations, type: :boolean, default: false


### PR DESCRIPTION
Use the same name as the extension. Makes it actually run as part of the `rake test_app`. Also, more intuitive for users.
