### PR TITLE
Fix rails 5.x ORDER BY change

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -2,6 +2,6 @@ Spree::Product.class_eval do
   has_many :nonuniq_variant_images, -> { order(:position) }, source: :variant_images, through: :variants_including_master
 
   def variant_images
-    nonuniq_variant_images.distinct
+    nonuniq_variant_images.unscope(:order).distinct
   end
 end


### PR DESCRIPTION
ActiveRecord recently made a small change that causes the following
error in master:

     ActiveRecord::StatementInvalid:
       PG::InvalidColumnReference: ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
       LINE 1: ...L AND "spree_variants"."product_id" = $1 ORDER BY "spree_var...
                                                                    ^
       : SELECT COUNT(*) FROM (SELECT DISTINCT "spree_assets_variants".* FROM "spree_assets_variants" INNER JOIN "spree_variants" ON "spree_assets_variants"."variant_id" = "spree_variants"."id" WHERE "spree_variants"."deleted_at" IS NULL AND "spree_variants"."product_id" = $1 ORDER BY "spree_variants"."position" ASC) subquery_for_count

We can fix this by removing all the ORDER BYs in one spot.

This should fix the current travis fails for solidus 2.3-master.