### PR TITLE
Fix Travis issue with Solidus old versions (Factory Bot gem)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
@@ -7,11 +9,20 @@ if branch == 'master' || branch >= "v2.0"
   gem "rails-controller-testing", group: :test
 end
 
-gem 'pg', '~> 0.21'
-gem 'mysql2', '~> 0.4.10'
+if ENV['DB'] == 'mysql'
+  gem 'mysql2', '~> 0.4.10'
+else
+  gem 'pg', '~> 0.21'
+end
 
 group :development, :test do
   gem "pry-rails"
+
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
 end
 
 gemspec

--- a/solidus_asset_variant_options.gemspec
+++ b/solidus_asset_variant_options.gemspec
@@ -27,6 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sass-rails"
   s.add_development_dependency "coffee-rails"
   s.add_development_dependency "database_cleaner"
-  s.add_development_dependency "factory_bot"
   s.add_development_dependency "ffaker"
 end


### PR DESCRIPTION
For Solidus versions older than `v2.5` gem `factory_bot 4.10.0` must be used
for compatibility reasons.