### PR TITLE
Use Rails helper from Solidus Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,7 @@ source "https://rubygems.org"
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem "solidus", github: "solidusio/solidus", branch: branch
 
-if branch == 'master' || branch >= "v2.0"
-  gem "rails-controller-testing", group: :test
-end
+gem "rails-controller-testing", group: :test
 
 if ENV['DB'] == 'mysql'
   gem 'mysql2', '~> 0.4.10'

--- a/solidus_asset_variant_options.gemspec
+++ b/solidus_asset_variant_options.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.add_dependency "solidus", ['>= 1.1', '< 3']
-  s.add_dependency "solidus_support"
+  s.add_dependency "solidus_support", "~> 0.2.2"
 
   s.add_development_dependency "rspec-rails",  "~> 3.4"
   s.add_development_dependency "simplecov"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # Run Coverage report
 require "simplecov"
+
 SimpleCov.start do
   add_filter "spec/dummy"
   add_group "Controllers", "app/controllers"
@@ -14,42 +15,23 @@ end
 ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
-
-require "rspec/rails"
-
-require "database_cleaner"
-require "ffaker"
-
-require "spree/testing_support/factories"
+require 'solidus_support/extension/rails_helper'
 require "spree_asset_variant_options/factories"
 
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
-  config.mock_with :rspec
-
-  config.color = true
-  config.order = "random"
-
   config.expose_current_running_example_as :example
-  config.fail_fast = ENV["FAIL_FAST"] || false
-
-  config.filter_run focus: true
-  config.run_all_when_everything_filtered = true
   config.use_transactional_fixtures = false
-
-  config.include FactoryBot::Syntax::Methods
 
   # Ensure Suite is set to use transactions for speed.
   config.before :suite do
     DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with :truncation
   end
 
   # Before each spec check if it is a Javascript test and switch between using database transactions or not where necessary.
   config.before :each do |example|
-    DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction
     DatabaseCleaner.start
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,6 @@ require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require 'solidus_support/extension/rails_helper'
 require "spree_asset_variant_options/factories"
 
-Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
-
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.expose_current_running_example_as :example


### PR DESCRIPTION
Based on the work done in solidusio/solidus_auth_devise#106, this PR follows suit by requiring Solidus Support Rails spec helper for this extension to achieve a more consistent development environment.